### PR TITLE
Enable sourcemaps for debugging webpack's output

### DIFF
--- a/config/webpack/dev.js
+++ b/config/webpack/dev.js
@@ -6,7 +6,8 @@ var stylelint = require('stylelint');
 var ManifestPlugin = require('webpack-manifest-plugin');
 
 var config = {
-  devtool: 'eval',
+  // Enable sourcemaps for debugging webpack's output.
+  devtool: 'source-map',
 
   debug: true,
 


### PR DESCRIPTION
Hi there

Current version doesn't emit source maps, making debugging obviously harder.

Here is the documentation for webpack's devtool configuration https://webpack.github.io/docs/configuration.html#devtool

