### PR TITLE
Add .gitattributes to normalize on LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Existing repo and .editorconfig already configured for LF, but the typical Windows environment has globally set `autocrlf=true`, so git ends up trying to convert all the LF stuff to CRLF when touching files. With this change, both git and editors cooperate on keeping files with LF ending.