### PR TITLE
Change react-addons-test-utils version tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "postcss-assets": "^4.1.0",
     "postcss-cssnext": "^2.8.0",
     "postcss-loader": "^1.0.0",
-    "react-addons-test-utils": "^15.3.2",
+    "react-addons-test-utils": "~15.3.2",
     "react-hot-loader": "^1.3.0",
     "redux-logger": "^2.7.0",
     "redux-mock-store": "^1.2.1",


### PR DESCRIPTION
Module react-addons-test-utils and react-dom should use same
version, otherwise test would fail to start.
Fix issue #102