### PR TITLE
Fix relative paths for favicon and public

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -46,9 +46,9 @@ if (process.env.NODE_ENV !== 'production') {
   app.use(require('webpack-hot-middleware')(webpackCompiler));
 }
 
-app.use(favicon(path.join(__dirname, '../src/favicon.ico')));
+app.use(favicon(path.join(__dirname, 'public/favicon.ico')));
 
-app.use('/public', express.static(path.join(__dirname, '../build/public')));
+app.use('/public', express.static(path.join(__dirname, 'public')));
 
 app.get('*', (req, res) => {
   const location = req.url;


### PR DESCRIPTION
The following changes make it possible to just straight up deploy the `build` directory as root to a host like e.g Azure App, without including the rest of the repo.

The only thing missing is the copying of the `src/favicon.ico` to `build/public/favicon.ico` during the build,
I was wondering about the desired approach..
