### PR TITLE
Fix postcss-loader not working in Production

### DIFF
--- a/config/webpack/prod.js
+++ b/config/webpack/prod.js
@@ -60,17 +60,17 @@ var config = {
         test: /\.css$/,
         include: path.resolve('./src/app'),
         loader: ExtractTextPlugin.extract(
-          'style-loader',
-          'css-loader?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]',
-          'postcss-loader'
+          'style-loader', [
+            'css-loader?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]',
+            'postcss-loader'
+          ]
         )
       },
       {
         test: /\.css$/,
         exclude: path.resolve('./src/app'),
         loader: ExtractTextPlugin.extract(
-          'style-loader',
-          'css-loader'
+          'style-loader', ['css-loader']
         )
       },
       {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "classnames": "^2.2.5",
     "compression": "^1.6.2",
     "cross-env": "^3.1.3",
-    "css-loader": "^0.25.0",
+    "css-loader": "^0.26.1",
     "enzyme": "^2.4.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "fetch-mock": "^5.5.0",


### PR DESCRIPTION
The first extract parameter is the "dontExtract" parameter. The second parameter is the loader(s) parameter.
To use multiple loaders, it has to be an array (Third parameter etc is ignored).

[Related](https://github.com/webpack/extract-text-webpack-plugin/issues/206#issuecomment-249523310)