### PR TITLE
Fix gitattributes not to corrupt binary files like .png

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,26 @@
 * text eol=lf
+
+#
+## These files are binary and should be left untouched
+#
+
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary


### PR DESCRIPTION
Corrupted my pngs a third time now when switching branches, thought this one would come in handy ;-)