### PR TITLE
React-router typings version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/react-dom": "^0.14.20",
     "@types/react-helmet": "0.0.27",
     "@types/react-redux": "^4.4.35",
-    "@types/react-router": "^2.0.45",
+    "@types/react-router": "^3.0.2",
     "@types/react-router-redux": "^4.0.38",
     "@types/redux": "^3.6.31",
     "@types/redux-devtools": "^3.0.36",


### PR DESCRIPTION
Updated the react-router typings to 3.0.2 which will allow the project to compile. This is a fix as suggested in #118 