### PR TITLE
Fix XSS issue in server-side rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/redux-devtools-log-monitor": "^1.0.29",
     "@types/redux-mock-store": "0.0.7",
     "@types/redux-thunk": "^2.1.31",
+    "@types/serialize-javascript": "1.3.1",
     "@types/sinon": "^1.16.34",
     "@types/source-map": "^0.5.0",
     "@types/uglify-js": "^2.6.28",
@@ -161,6 +162,7 @@
     "redux-connect": "^5.0.0",
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.2.0",
+    "serialize-javascript": "1.3.0",
     "serve-favicon": "^2.3.2"
   }
 }

--- a/src/app/containers/Html/index.tsx
+++ b/src/app/containers/Html/index.tsx
@@ -1,6 +1,7 @@
 import { IStore } from 'redux/IStore';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import * as serialize from 'serialize-javascript';
 
 interface IHtmlProps {
   manifest?: any;
@@ -31,7 +32,10 @@ class Html extends React.Component<IHtmlProps, {}> {
     );
 
     // tslint:disable-next-line:max-line-length
-    const initialState = (<script dangerouslySetInnerHTML={{ __html: `window.__INITIAL_STATE__=${JSON.stringify(store.getState())};` }} charSet="UTF-8" />);
+    const initialState = (
+      <script dangerouslySetInnerHTML={{ __html: `window.__INITIAL_STATE__=${serialize(store.getState(), { isJSON: true })};` }}
+              charSet="UTF-8" />
+    );
 
     return (
       <html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,6 +124,10 @@
   version "3.6.31"
   resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.31.tgz#40eafa7575db36b912ce0059b85de98c205b0708"
 
+"@types/serialize-javascript@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/serialize-javascript/-/serialize-javascript-1.3.1.tgz#9ae324d5b07af5a35e83ab232fba88463e3432ba"
+
 "@types/sinon@^1.16.34":
   version "1.16.35"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.35.tgz#ee687cc42d1a79448256f1c012a33a0840e85c5c"
@@ -5252,6 +5256,10 @@ send@0.15.0:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
+
+serialize-javascript@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.3.0.tgz#86a4f3752f5c7e47295449b0bbb63d64ba533f05"
 
 serve-favicon@^2.3.2:
   version "2.4.1"


### PR DESCRIPTION
```react-router-redux``` state is transferred to browser in ```window.__INITIAL_STATE__``` of server-side generated HTML. This causes XSS vulnerability, because the contents of ```routing``` map are affected by the requested URL.

Example (display alert dialog in frontpage):
http://localhost:8889?<%2fscript><script>alert('foobar')<%2fscript>

Fixed by escaping all the HTML characters.