### PR TITLE
missing quote in unit-whitelist

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,6 +7,6 @@
       "except": ["value"]
     }],
     "max-empty-lines": 2,
-    "unit-whitelist": ["px", em", "rem", "%", "s"]
+    "unit-whitelist": ["px", "em", "rem", "%", "s"]
   }
 }


### PR DESCRIPTION
I happened to notice the missing quote. Fixed