### PR TITLE
#150 Fixing build failing with TS2322: Type 'Store<{}>' is not assignable … in store.ts

### DIFF
--- a/src/app/redux/store.ts
+++ b/src/app/redux/store.ts
@@ -23,7 +23,7 @@ export function configureStore(history, initialState?: IStore): Redux.Store<ISto
     typeof window === 'object' &&
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
-  const store = createStore(rootReducer, initialState, composeEnhancers(
+  const store: Redux.Store<IStore> = createStore(rootReducer, initialState, composeEnhancers(
     applyMiddleware(...middlewares),
   ));
 


### PR DESCRIPTION
Adding missing type declaration to fix the build error.